### PR TITLE
WIP - fix auth flow

### DIFF
--- a/client/src/components/GoogleSignInButton.vue
+++ b/client/src/components/GoogleSignInButton.vue
@@ -14,16 +14,7 @@
 
 <script>
 import { mapActions } from 'vuex'
-
-const asyncGApiLoad = async () => {
-  if (window.gapi) {
-    return new Promise((resolve, reject) => {
-      window.gapi.load('client:auth2', { callback: resolve, onerror: reject })
-    })
-  } else {
-    return Promise.reject(new Error('Google API not available for load'))
-  }
-}
+import { asyncGApiLoad, asyncGApiInit } from '@/services/GApi'
 
 export default {
   name: 'GoogleSignInButton',
@@ -46,9 +37,7 @@ export default {
       await asyncGApiLoad()
 
       // Init auth instance
-      const googleAuth = await window.gapi.auth2.init({
-        client_id: process.env.VUE_APP_GOOGLE_CLIENT_ID
-      })
+      const googleAuth = await asyncGApiInit()
 
       // Attach handler to button
       googleAuth.attachClickHandler(this.$refs['sign-in'], {},
@@ -63,7 +52,12 @@ export default {
 
       // If user is already logged in
       if (googleAuth.isSignedIn.get()) {
-        this.logIn(googleAuth.currentUser.get())
+        const user = await googleAuth.currentUser.get()
+        this.logIn({
+          name: user.getBasicProfile().getGivenName(),
+          imageUrl: user.getBasicProfile().getImageUrl()
+        })
+        this.$router.push({ name: 'flags' })
       }
     } catch (error) {
       this.error = error

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -32,14 +32,20 @@ const router = new Router({
   ]
 })
 
-router.beforeEach((to, from, next) => {
-
+// Auth navigation guard
+router.beforeEach(async (to, from, next) => {
   if (to.matched.some(record => record.meta.requiresAuth)) {
-    if (store.getters.isAuthenticated) {
-      next()
-      return
+    const hasStartedAuthentication = await store.getters.hasStartedAuthentication
+    if (!hasStartedAuthentication) {
+      await store.dispatch('startAuthentication')
+    } else {
+      const isAuthenticated = await store.getters.isAuthenticated
+      if (!isAuthenticated) {
+        next({ name: 'auth' })
+      } else {
+        next()
+      }
     }
-    next({ name: 'auth' })
   } else {
     next()
   }

--- a/client/src/services/GApi.js
+++ b/client/src/services/GApi.js
@@ -1,0 +1,13 @@
+export const asyncGApiLoad = async () => {
+  if (window.gapi) {
+    return new Promise((resolve, reject) => {
+      window.gapi.load('client:auth2', { callback: resolve, onerror: reject })
+    })
+  } else {
+    return Promise.reject(new Error('Google API not available for load'))
+  }
+}
+
+export const asyncGApiInit = async () => window.gapi.auth2.init({
+  client_id: process.env.VUE_APP_GOOGLE_CLIENT_ID
+})


### PR DESCRIPTION
### Problem
The auth flow is wrongly architectured. Only the `google sign in` component is doing the auth, therefore any other URL would go to the auth `/` route first. This causes specific use URL like `/flags?id=1` or `/flags?tags=tag1` to get lost and therefore the functionality for them is not working.

### How to fix it
Checking the user authentication state during the app load, asynchronously. If failing, then forward users to `/`, otherwise keep the navigation route.

### How to know if it's working
Try `/flags?id=1` or `/flags?tags=tag1`

# WIP
This solution is still not working